### PR TITLE
Update edge.sh

### DIFF
--- a/edge.sh
+++ b/edge.sh
@@ -1,11 +1,28 @@
 #!/bin/bash
+APP="couchpotato"
+REPO="https://github.com/RuudBurger/CouchPotatoServer.git"
+INSTALLDIR="/opt/${APP}"
 
 # Does the user want the latest version
 if [ -z "$EDGE" ]; then
   echo "Bleeding edge not requested"
+elif [[ -f /tmp/edge_installed ]]; then
+  echo "Updating source..."
+  cd /opt/${APP}
+  git pull
 else
-  apt-get install -qy git
-  rm -rf /opt/couchpotato
-  git clone https://github.com/RuudBurger/CouchPotatoServer.git /opt/couchpotato
-  chown -R nobody:users /opt/couchpotato
+  apt-get install -qy git >/dev/null
+  echo "Downloading source..."
+  tmpdir="/tmp/tmp.$(( $RANDOM * $RANDOM * $RANDOM * $RANDOM ))"
+  git clone ${REPO} $tmpdir
+  if [[ $? -eq 0 ]]; then
+    rm -rf /opt/${APP}
+    mv $tmpdir /opt/${APP}
+    touch /tmp/edge_installed
+  else
+    rm -rf $tmpdir
+  fi
 fi
+
+# Fix permissions
+chown -R nobody:users /opt/${APP}


### PR DESCRIPTION
Better edge function:
1) will try to clone the repository to a temp dir;
2) if it succeed, will erase the install dir and move the temp dir to it's place;
3) will create a /tmp/edge_installed, so the source can be updated by a simple git pull;
4) if the clone fails, will remove the temp dir, leaving the current version intact.

This will avoid internet timeout problems and will make the source update faster.
