### PR TITLE
remove `-p` from the readme file instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This is a Dockerfile setup for couchpotato - https://couchpota.to/
 By default this Docker installs the latest stable version of CouchPotato:
 
 ```
-docker run -d --net="host" --name="couchpotato" -v /path/to/couchpotato/data:/config -v /path/to/downloads:/downloads -v /path/to/movies:/movies -v /etc/localtime:/etc/localtime:ro -p 5050:5050 needo/couchpotato
+docker run -d --net="host" --name="couchpotato" -v /path/to/couchpotato/data:/config -v /path/to/downloads:/downloads -v /path/to/movies:/movies -v /etc/localtime:/etc/localtime:ro needo/couchpotato
 ```
 
 Edge
@@ -11,5 +11,5 @@ Edge
 If you would like to run the latest updates from the master branch as well as enable in-app updates run:
 
 ```
-docker run -d --net="host" --name="couchpotato" -v /path/to/couchpotato/data:/config -v /path/to/downloads:/downloads -v /path/to/movies:/movies -v /etc/localtime:/etc/localtime:ro -e EDGE=1 -p 5050:5050 needo/couchpotato
+docker run -d --net="host" --name="couchpotato" -v /path/to/couchpotato/data:/config -v /path/to/downloads:/downloads -v /path/to/movies:/movies -v /etc/localtime:/etc/localtime:ro -e EDGE=1 needo/couchpotato
 ```


### PR DESCRIPTION
as the `-p` docker run option is ignored when used with `--net="host"`.
